### PR TITLE
enforce utf-8 encoding when we open data.json

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -30,7 +30,7 @@ def main():
 
 
     print("\033[1;92m[\033[0m\033[1;77m*\033[0m\033[1;92m] Checking username\033[0m\033[1;37m {}\033[0m\033[1;92m on: \033[0m".format(username))
-    raw = open("data.json", "r")
+    raw = open("data.json", "r", encoding="utf-8")
     data = json.load(raw)
 
     # User agent is needed because some sites does not 


### PR DESCRIPTION
On my Windows machine, json.load(raw) raises error due to the default encoding chosen by open(). I believe this affects other machines that does not use utf-8 as default. We can get around this problem by enforcing 'utf-8' when we open data.json.