### PR TITLE
Allow Site-Specific Username Checking By Regular Expression

### DIFF
--- a/data.json
+++ b/data.json
@@ -21,7 +21,7 @@
   "Blogger": {
     "url": "https://{}.blogspot.com",
     "errorType": "status_code",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Google Plus": {
     "url": "https://plus.google.com/+{}",
@@ -40,7 +40,7 @@
   "GitHub": {
     "url": "https://www.github.com/{}",
     "errorType": "status_code",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$"
   },
   "Steam": {
     "url": "https://steamcommunity.com/id/{}",
@@ -67,7 +67,7 @@
   "DeviantART": {
     "url": "https://{}.deviantart.com",
     "errorType": "status_code",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "VK": {
     "url": "https://vk.com/{}",
@@ -165,13 +165,13 @@
     "url": "https://www.kongregate.com/accounts/{}",
     "errorType": "message",
     "errorMsg": "Sorry, no account with that name was found.",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "LiveJournal": {
     "url": "https://{}.livejournal.com",
     "errorType": "message",
     "errorMsg": "Unknown Journal",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "VSCO": {
     "url": "https://vsco.co/{}",
@@ -191,7 +191,7 @@
     "url": "https://dribbble.com/{}",
     "errorType": "message",
     "errorMsg": "Whoops, that page is gone.",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Codecademy": {
     "url": "https://www.codecademy.com/{}",
@@ -215,7 +215,7 @@
   "Newgrounds": {
     "url": "https://{}.newgrounds.com",
     "errorType": "status_code",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Wattpad": {
     "url": "https://www.wattpad.com/user/{}",
@@ -251,7 +251,7 @@
     "url": "https://{}.contently.com/",
     "errorType": "message",
     "errorMsg": "We can't find that page!",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Houzz": {
     "url": "https://houzz.com/user/{}",
@@ -306,7 +306,7 @@
   "Slack": {
     "url": "https://{}.slack.com",
     "errorType": "status_code",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Trip": {
     "url": "https://www.trip.skyscanner.com/user/{}",
@@ -341,7 +341,7 @@
     "url": "https://{}.wordpress.com",
     "errorType": "response_url",
     "errorUrl": "wordpress.com/typo/?subdomain=",
-    "noPeriod": "True"
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$"
   },
   "Unsplash": {
     "url": "https://unsplash.com/@{}",

--- a/sherlock.py
+++ b/sherlock.py
@@ -2,6 +2,7 @@ import requests
 import json
 import os
 import sys
+import re
 import argparse
 
 DEBUG = False
@@ -67,12 +68,17 @@ def sherlock(username):
     for social_network in data:
         url = data.get(social_network).get("url").format(username)
         error_type = data.get(social_network).get("errorType")
-        cant_have_period = data.get(social_network).get("noPeriod")
+        regex_check = data.get(social_network).get("regexCheck")
 
-        if ("." in username) and (cant_have_period == "True"):
-            print("\033[37;1m[\033[91;1m-\033[37;1m]\033[92;1m {}:\033[93;1m User Name Not Allowed!".format(social_network))
+        if regex_check is None:
+            #Use default regular expression check for user names.
+            regex_check = "^[a-zA-Z][a-zA-Z0-9._-]*$"
+
+        if re.search(regex_check, username) is None:
+            #No need to do the check at the site: this user name is not allowed.
+            print("\033[37;1m[\033[91;1m-\033[37;1m]\033[92;1m {}:\033[93;1m Illegal User Name Format For This Site!".format(social_network))
             continue
-            
+
         r, error_type = make_request(url=url, headers=headers, error_type=error_type, social_network=social_network)
         
         if error_type == "message":


### PR DESCRIPTION
Replace noPeriod attribute in JSON file with a regexCheck attribute.  If this does not exist in the JSON file, then there will be a default regular expression that will be used.  By default, the allowed user name pattern requires that the first character is alphabetic, while the following characters are either alphanumeric or ".", "_", or "-".  Also, specifically indicate that the user name is invalid in the feedback.
