### PR TITLE
Altered regex_check logic

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -63,11 +63,7 @@ def sherlock(username, verbose=False):
         error_type = data.get(social_network).get("errorType")
         regex_check = data.get(social_network).get("regexCheck")
 
-        if regex_check is None:
-            #Use default regular expression check for user names.
-            regex_check = "^[a-zA-Z][a-zA-Z0-9._-]*$"
-
-        if re.search(regex_check, username) is None:
+        if regex_check and re.search(regex_check, username) is None:
             #No need to do the check at the site: this user name is not allowed.
             print("\033[37;1m[\033[91;1m-\033[37;1m]\033[92;1m {}:\033[93;1m Illegal User Name Format For This Site!".format(social_network))
             continue


### PR DESCRIPTION
### TL;DR
Removed default regular expression check, only check when regular expression is specified in the settings file.

### Full explanation
In the old code, a default regular expression ("^[a-zA-Z][a-zA-Z0-9._-]*$") was set to check the username against if no regex for the specific website was set in the settings file. When no regex for the specific website is set, however, it is impossible to determine whether a username is actually invalid even if it does not match the default regex. 

A nice example is flickr.com: a user with as username "00" exists on the website ([link](https://www.flickr.com/people/00)), but would not match the default regular expression and would thus never be checked. This actually goes for all usernames starting with a number. Altering the default regular expression could of course eliminate this edge-case, but is bound to leave other edge-cases uncovered as "the right" regex for usernames on all websites is simply not known.

In the new code, if regex_check does not exist (becomes None), the and clause will fail and the re.search part will not be executed. This way, no error occurs when regex_check is None. 