### PR TITLE
Added options to connect over TOR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+torrequest

--- a/sherlock.py
+++ b/sherlock.py
@@ -164,7 +164,7 @@ def main():
     if args.tor or args.unique_tor:
         print("Warning: some websites might refuse connecting over TOR, so note that using this option might increase connection errors.")
 
-    # Run report on     all specified users.
+    # Run report on all specified users.
     for username in args.username:
         print()
         sherlock(username, verbose=args.verbose, tor=args.tor, unique_tor=args.unique_tor)


### PR DESCRIPTION
### TL;DR
Added options to connect over TOR.

### Full explanation
For those who value privacy, it might be important to be able to connect over TOR. This PR adds two command line arguments:

- --tor or -t: set up a TOR circuit to connect to all websites using the torrequest package.
- --unique-tor or -u: sets up a unique TOR circuit for each website using the torrequest package.

As connecting over TOR is only possible when TOR is installed/in the system PATH, this requirement is also referred to in the documentation of the CL arguments. The documentation now also mentions that connecting over TOR (especially establishing new circuits) adds to the runtime of the program.

Finally, as can happen with any IP, some services might decide to block requests coming from known TOR exit nodes. This might increase connection errors and thus a warning message was added to inform the user about this potential consequence.