### PR TITLE
Script can load the data.json file when invoked from different directory

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -90,7 +90,8 @@ def sherlock(username, verbose=False, tor=False, unique_tor=False):
     }
 
     # Load the data
-    raw = open("data.json", "r", encoding="utf-8")
+    script_directory = os.path.dirname(os.path.realpath(__file__))
+    raw = open(script_directory + "/data.json", "r", encoding="utf-8")
     data = json.load(raw)
 
     # Allow 1 thread for each external service, so `len(data)` threads total


### PR DESCRIPTION
If the script is run from a different directory than the where it
resides then it would fail to load because it could not find data.json.
fixes #47